### PR TITLE
Expand path to pandoc bin

### DIFF
--- a/R/pandoc-available.R
+++ b/R/pandoc-available.R
@@ -20,11 +20,13 @@ pandoc_bin_impl <- function(path, exe = FALSE) {
 pandoc_bin <- function(version = "default") {
   version <- resolve_version(version)
   if (pandoc_is_external_version(version)) {
-    return(pandoc_which_bin(version))
+    pandoc_path <- pandoc_which_bin(version)
+    return(fs::path_expand(pandoc_path))
   }
 
   pandoc_path <- pandoc_locate(version)
-  pandoc_bin_impl(pandoc_path)
+  pandoc_path <- pandoc_bin_impl(pandoc_path)
+  fs::path_expand(pandoc_path)
 }
 
 pandoc_which_bin <- function(which = c("rstudio", "system")) {


### PR DESCRIPTION
MacOS doesn't like the unexpanded path to the pandoc bin in `~/Library/Application Support/...`. Expanding the path to an absolute path resolves the problem (for me at least, I'm not sure if there are Windows implications).

``` r
gert::git_branch_checkout("main")
pkgload::load_all()
#> ℹ Loading pandoc
pandoc_bin()
#> ~/Library/Application Support/r-pandoc/2.17.1.1/pandoc
pandoc_run("--version")
#> sh: ~/Library/Application Support/r-pandoc/2.17.1.1/pandoc: No such file or directory
#> Error in system2(bin, args, stdout = TRUE): error in running command

gert::git_branch_checkout("expand-paths")
pkgload::load_all()
#> ℹ Loading pandoc
pandoc_bin()
#> /Users/garrick/Library/Application Support/r-pandoc/2.17.1.1/pandoc
pandoc_run("--version")
#> [1] "pandoc 2.17.1.1"                                                            
#> [2] "Compiled with pandoc-types 1.22.1, texmath 0.12.4, skylighting 0.12.2,"     
#> [3] "citeproc 0.6.0.1, ipynb 0.2"                                                
#> [4] "User data directory: /Users/garrick/.local/share/pandoc"                    
#> [5] "Copyright (C) 2006-2022 John MacFarlane. Web:  https://pandoc.org"          
#> [6] "This is free software; see the source for copying conditions. There is no"  
#> [7] "warranty, not even for merchantability or fitness for a particular purpose."
```