### PR TITLE
Fix space issues in path for pandoc CLI

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: pandoc
 Title: Manage and Run Universal Converter 'Pandoc' from 'R'
-Version: 0.1.0.9002
+Version: 0.1.0.9003
 Authors@R: c(
     person("Christophe", "Dervieux", , "cderv@posit.co", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-4474-2498")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,9 +1,11 @@
 # pandoc (development version)
 
-- Fix Pandoc 3.1.2 and above on Mac as Pandoc bundles' name have changed.
+-   Fix Pandoc 3.1.2 and above on Mac as Pandoc bundles' name have changed.
 
-- Fix an issue in installation on Mac M1 with broken external Pandoc.
+-   Fix an issue in installation on Mac M1 with broken external Pandoc.
+
+-   Fix an issue with file path with space in `pandoc_convert()` and `pandoc_export_*()` (thanks, @krlmlr, #32).
 
 # pandoc 0.1.0
 
-* First release
+-   First release

--- a/R/pandoc-convert.R
+++ b/R/pandoc-convert.R
@@ -51,9 +51,9 @@ pandoc_convert <- function(file = NULL,
     "--from", from,
     "--to", to,
     if (standalone) "--standalone",
-    if (!is.null(output)) c("--output", output),
+    if (!is.null(output)) c("--output", shQuote(output)),
     args,
-    file
+    shQuote(file)
   )
 
   res <- pandoc_run(args, version = version)

--- a/R/pandoc-template.R
+++ b/R/pandoc-template.R
@@ -29,7 +29,7 @@ pandoc_export_template <- function(format = "markdown", output = NULL, version =
     preview <- TRUE
   }
   args <- c(
-    "--output", output,
+    "--output", shQuote(output),
     "--print-default-template", format
   )
   pandoc_run(args, version = version)
@@ -81,7 +81,7 @@ pandoc_export_data_file <- function(file, output = file, version = "default") {
     file <- "templates/styles.html"
   }
   args <- c(
-    "--output", output,
+    "--output", shQuote(output),
     "--print-default-data-file", file
   )
   pandoc_run(args, version = version)
@@ -149,7 +149,7 @@ pandoc_export_highlight_theme <- function(style = "pygments", output = style, ve
   }
   output <- fs::path_ext_set(output, ".theme")
   args <- c(
-    "--output", output,
+    "--output", shQuote(output),
     "--print-highlight-style", style
   )
   pandoc_run(args, version = version)

--- a/tests/testthat/test-pandoc-convert.R
+++ b/tests/testthat/test-pandoc-convert.R
@@ -12,3 +12,14 @@ test_that("pandoc_convert()", {
   )
   expect_snapshot_file(tmp_file, "convert-markdown-dummy.md", compare = compare_file_text)
 })
+
+test_that("pandoc_convert() handles space in file path", {
+  skip_on_cran()
+  skip_if_offline()
+  suppressMessages(pandoc_install())
+  local_pandoc_version("latest")
+  tmp_dir <- withr::local_tempdir()
+  writeLines("# My Markdown", "my test.md")
+  expect_no_error(pandoc_convert("my test.md", to = "html"))
+  expect_no_error(pandoc_convert("my test.md", to = "html", output = "my test.html"))
+})

--- a/tests/testthat/test-pandoc-convert.R
+++ b/tests/testthat/test-pandoc-convert.R
@@ -22,4 +22,5 @@ test_that("pandoc_convert() handles space in file path", {
   writeLines("# My Markdown", "my test.md")
   expect_no_error(pandoc_convert("my test.md", to = "html"))
   expect_no_error(pandoc_convert("my test.md", to = "html", output = "my test.html"))
+  expect_true(fs::file_exists("my test.html"))
 })

--- a/tests/testthat/test-pandoc-template.R
+++ b/tests/testthat/test-pandoc-template.R
@@ -15,6 +15,16 @@ test_that("pandoc_export_template() exports templates for a format", {
   expect_snapshot_file(theme_file, "default.jira", compare = compare_file_text)
 })
 
+test_that("pandoc_export_template() handles space in file path", {
+  skip_on_cran()
+  skip_if_offline()
+  suppressMessages(pandoc_install())
+  local_pandoc_version("latest")
+  withr::local_dir(tempdir())
+  expect_no_error(suppressMessages(pandoc_export_template("jira", output = "path with space.jira")))
+  expect_true(fs::file_exists("path with space.jira"))
+})
+
 test_that("pandoc_export_data_file() exports data file", {
   skip_on_cran()
   skip_if_offline()
@@ -57,6 +67,16 @@ test_that("pandoc_export_data_file() exports data file", {
   unlink(theme_file)
 })
 
+test_that("pandoc_export_data_file() handles space in file path", {
+  skip_on_cran()
+  skip_if_offline()
+  suppressMessages(pandoc_install())
+  local_pandoc_version("latest")
+  withr::local_dir(tempdir())
+  expect_no_error(suppressMessages(pandoc_export_data_file("styles.html", output = "my styles.html")))
+  expect_true(fs::file_exists("my styles.html"))
+})
+
 test_that("pandoc_export_highlight_theme() exports .theme file", {
   skip_on_cran()
   skip_if_offline()
@@ -85,4 +105,14 @@ test_that("pandoc_export_highlight_theme() exports .theme file", {
     theme_file <- pandoc_export_highlight_theme("tango", output = tmp_file)
   )
   expect_snapshot_file(theme_file, "tango.theme", compare = compare_file_text)
+})
+
+test_that("pandoc_export_highlight_theme() handles space in file path", {
+  skip_on_cran()
+  skip_if_offline()
+  suppressMessages(pandoc_install())
+  local_pandoc_version("latest")
+  withr::local_dir(tempdir())
+  expect_no_error(suppressMessages(pandoc_export_highlight_theme(output = "my theme.theme")))
+  expect_true(fs::file_exists("my theme.theme"))
 })


### PR DESCRIPTION
pandoc_convert() needs to quote paths when calling build argument to pandoc

Also `pandoc_export_*` needs quoting for there outputs

fix #32 