### PR TITLE
add gh_wrapper to fallback for 401 http errors

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # pandoc (development version)
 
+-   pandoc installation will no longer immediately fail for users with bad 
+    GitHub credentials
+
 # pandoc 0.2.0
 
 -   input and output path containing short path version using `~` now works (thanks, @olivroy, #31)


### PR DESCRIPTION
This allows users with bad credentials (they expired or were misconfigured in the first place) to install pandoc using the limited API without credentials.

This will fix #30