### PR TITLE
Correctly capture stderr in pandoc_run

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: pandoc
 Title: Manage and Run Universal Converter 'Pandoc' from 'R'
-Version: 0.2.0.9000
+Version: 0.2.0.9001
 Authors@R: c(
     person("Christophe", "Dervieux", , "cderv@posit.co", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-4474-2498")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,14 +1,16 @@
 # pandoc (development version)
 
+-   Correctly order error message of Pandoc failure (thanks, \@hadley, #39).
+
 # pandoc 0.2.0
 
--   input and output path containing short path version using `~` now works (thanks, @olivroy, #31)
+-   input and output path containing short path version using `~` now works (thanks, \@olivroy, #31)
 
 -   `pandoc_install()` now works for Pandoc 3.1.2 and above on Mac as Pandoc bundles' name have changed.
 
 -   `pandoc_install()` works now on Mac M1.
 
--   `pandoc_convert()` and `pandoc_export_*()` now handles filepath with space (thanks, @krlmlr, #32).
+-   `pandoc_convert()` and `pandoc_export_*()` now handles filepath with space (thanks, \@krlmlr, #32).
 
 # pandoc 0.1.0
 

--- a/R/pandoc-run.R
+++ b/R/pandoc-run.R
@@ -21,7 +21,7 @@ pandoc_run <- function(args, version = "default") {
   # Seems like expansion is needed (https://github.com/cderv/pandoc/pull/15)
   # not doing it on windows because `~` does not mean the same for {fs}
   if (pandoc_os() != "windows") bin <- fs::path_expand(bin)
-  res <- suppressWarnings(system2(bin, args, stdout = TRUE))
+  res <- suppressWarnings(system2(bin, args, stdout = TRUE, stderr = TRUE))
   status <- attr(res, "status", TRUE)
   if (length(status) > 0 && status > 0) {
     rlang::abort(c("Running Pandoc failed with following error", res))

--- a/tests/testthat/_snaps/pandoc-run.md
+++ b/tests/testthat/_snaps/pandoc-run.md
@@ -1,0 +1,9 @@
+# Pandoc error is shown
+
+    Code
+      pandoc::pandoc_run(c("--to", "word", tmp))
+    Condition
+      Error in `pandoc::pandoc_run()`:
+      ! Running Pandoc failed with following error
+      * Unknown output format word
+

--- a/tests/testthat/test-pandoc-run.R
+++ b/tests/testthat/test-pandoc-run.R
@@ -52,3 +52,14 @@ test_that("rmarkdown version is correctly set / reset", {
   expect_equal(rmarkdown::find_pandoc(), before_with)
   expect_equal(pandoc_version(), as.numeric_version("2.18"))
 })
+
+test_that("Pandoc error is shown", {
+  skip_on_cran()
+  skip_if_offline()
+  suppressMessages(pandoc_install("2.18"))
+  local_pandoc_version("2.18")
+  tmp <- withr::local_tempfile(fileext = ".md")
+  write_utf8("dummy", tmp)
+  expect_identical(pandoc::pandoc_run(c("--to", "gfm", tmp)), "dummy")
+  expect_snapshot(pandoc::pandoc_run(c("--to", "word", tmp)), error = TRUE)
+})


### PR DESCRIPTION
So that the error can be shown within `rlang::abort()` correctly

fixes #39