### PR TITLE
`pandoc_install_nightly()` does not fail when called while a Pandoc's nigthly workflow is currently running

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 -   Correctly order error message of Pandoc failure (thanks, \@hadley, #39).
 
+-   `pandoc_install_nightly()` does not fail when called while a Pandoc's nigthly workflow is currently running
+
 # pandoc 0.2.0
 
 -   input and output path containing short path version using `~` now works (thanks, \@olivroy, #31)

--- a/tests/testthat/test-pandoc-install.R
+++ b/tests/testthat/test-pandoc-install.R
@@ -331,3 +331,54 @@ test_that("Pandoc latest release can be installed", {
     fixed = TRUE
   )
 })
+
+test_that("Retrieving nightly does return only success without error", {
+  skip_on_cran()
+
+  expect_last_successful_run <- function(n) {
+    expect_message(
+      expect_identical(
+        get_last_nightly_run(),
+        list(conclusion = "success", n = n)
+      )
+    )
+  }
+
+  # simulate querying when last run is failure
+  with_mocked_bindings(
+    get_nightly_runs = function(...) {
+      list(
+        workflow_runs = list(
+          list(conclusion = "fail", n = 1),
+          list(conclusion = "success", n = 2)
+        )
+      )
+    },
+    expect_last_successful_run(n = 2)
+  )
+  # simulate querying several success
+  with_mocked_bindings(
+    get_nightly_runs = function(...) {
+      list(
+        workflow_runs = list(
+          list(conclusion = "success", n = 1),
+          list(conclusion = "success", n = 2),
+          list(conclusion = "success", n = 3)
+        )
+      )
+    },
+    expect_last_successful_run(n = 1)
+  )
+  # simulate querying during a run (conclusion will be NULL)
+  with_mocked_bindings(
+    get_nightly_runs = function(...) {
+      list(
+        workflow_runs = list(
+          list(conclusion = NULL, n = 1),
+          list(conclusion = "success", n = 2)
+        )
+      )
+    },
+    expect_last_successful_run(n = 2)
+  )
+})


### PR DESCRIPTION
`````
> pandoc::pandoc_install_nightly()
ℹ Retrieving last available nightly informations...
Error in `vapply()`:
! values must be length 1,
 but FUN(X[[1]]) result is length 0
Hide Traceback
    ▆
 1. └─pandoc::pandoc_install_nightly()
 2.   └─pandoc:::keep(runs$workflow_runs, ~.x$conclusion == "success")
 3.     └─pandoc:::.rlang_purrr_probe(.x, .f, ...)
 4.       └─pandoc:::map_lgl(.x, .p, ...)
 5.         └─pandoc:::.rlang_purrr_map_mold(.x, .f, logical(1), ...)
 6.           └─base::vapply(.x, .f, .mold, ..., USE.NAMES = FALSE)
````


This would happen when the function was called while a nightly workflow was currently running in GHA inside the Pandoc repo, as during a run, `x$conclusion` would be NULL